### PR TITLE
Make the HTTP timeout configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
 # CHANGELOG
 
-## v0.3
+## v0.4
 
 This release adds a new `timeoutMs` parameter to `StreamSource`, allowing you
 to choose how long to wait before timing out the connection to Sierra.
 
 This parameter is optional, and defaults to the previous timeout (10000 ms).
+
+## v0.3 - 2018-05-30
+
+This release contains no code changes, and is just a test of our new automated
+release process.
 
 ## v0.2 - 2018-01-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# CHANGELOG
+
+## v0.2 - 2018-01-11
+
+This release sends the "Connection: close" header on every request to Sierra,
+causing it to reset the HTTP session every time.
+
+This was based on an issue we saw with the Wellcome instance of Sierra where
+successive response in the same HTTP session would take exponentially longer
+to return.
+
+## v0.1 - 2017-11-22
+
+Initial release!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## v0.3
+
+This release adds a new `timeoutMs` parameter to `StreamSource`, allowing you
+to choose how long to wait before timing out the connection to Sierra.
+
+This parameter is optional, and defaults to the previous timeout (10000 ms).
+
 ## v0.2 - 2018-01-11
 
 This release sends the "Connection: close" header on every request to Sierra,

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A library for providing Akka Streams from objects in a Sierra API.
 
 ```scala
 libraryDependencies ++= Seq(
-  "uk.ac.wellcome" %% "sierra-streams-source" % "0.3"
+  "uk.ac.wellcome" %% "sierra-streams-source" % "0.4"
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ A library for providing Akka Streams from objects in a Sierra API.
 
 ```scala
 libraryDependencies ++= Seq(
-  "uk.ac.wellcome" %% "sierra-streams-source" % "0.1"
+  "uk.ac.wellcome" %% "sierra-streams-source" % "0.3"
 )
 ```
 
-sierra-streams-source is published for Scala 2.11 and Scala 2.12
+sierra-streams-source is published for Scala 2.11 and Scala 2.12.
 
 ## Basic Usage
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ organization := "uk.ac.wellcome"
 
 name := "sierra-streams-source"
 
-version := "0.3"
+version := "0.4"
 
 crossScalaVersions := Seq("2.11.11", "2.12.6")
 

--- a/src/main/scala/uk/ac/wellcome/sierra/SierraPageSource.scala
+++ b/src/main/scala/uk/ac/wellcome/sierra/SierraPageSource.scala
@@ -12,7 +12,8 @@ import scalaj.http.{Http, HttpOptions, HttpResponse}
 private[sierra] class SierraPageSource(
   apiUrl: String,
   oauthKey: String,
-  oauthSecret: String
+  oauthSecret: String,
+  timeoutMs: Int
 )(
   resourceType: String,
   params: Map[String, String] = Map()
@@ -102,8 +103,8 @@ private[sierra] class SierraPageSource(
     logger.debug(s"Making request with parameters $params & token $token")
 
     Http(url = s"$apiUrl/$resourceType")
-      .option(HttpOptions.readTimeout(10000))
-      .option(HttpOptions.connTimeout(10000))
+      .option(HttpOptions.readTimeout(timeoutMs))
+      .option(HttpOptions.connTimeout(timeoutMs))
       .params(params)
       .header("Authorization", s"Bearer $token")
       .header("Accept", "application/json")

--- a/src/main/scala/uk/ac/wellcome/sierra/SierraPageSource.scala
+++ b/src/main/scala/uk/ac/wellcome/sierra/SierraPageSource.scala
@@ -9,10 +9,14 @@ import org.slf4j.{Logger, LoggerFactory}
 
 import scalaj.http.{Http, HttpOptions, HttpResponse}
 
-private[sierra] class SierraPageSource(apiUrl: String, oauthKey: String, oauthSecret: String)(
+private[sierra] class SierraPageSource(
+  apiUrl: String,
+  oauthKey: String,
+  oauthSecret: String
+)(
   resourceType: String,
-  params: Map[String, String] = Map.empty)
-    extends GraphStage[SourceShape[List[Json]]] {
+  params: Map[String, String] = Map()
+) extends GraphStage[SourceShape[List[Json]]] {
 
   val out: Outlet[List[Json]] = Outlet("SierraSource")
 

--- a/src/main/scala/uk/ac/wellcome/sierra/SierraSource.scala
+++ b/src/main/scala/uk/ac/wellcome/sierra/SierraSource.scala
@@ -13,14 +13,22 @@ case object ThrottleRate {
 }
 
 object SierraSource {
-
-
-  def apply(apiUrl: String, oauthKey: String, oauthSecret: String, throttleRate: ThrottleRate)(
+  def apply(
+    apiUrl: String,
+    oauthKey: String,
+    oauthSecret: String,
+    throttleRate: ThrottleRate
+  )(
     resourceType: String,
     params: Map[String, String]): Source[Json, NotUsed] = {
 
     Source.fromGraph(
-      new SierraPageSource(apiUrl, oauthKey, oauthSecret)(resourceType, params)
+      new SierraPageSource(
+        apiUrl = apiUrl,
+        oauthKey = oauthKey,
+        oauthSecret = oauthSecret)(
+          resourceType = resourceType,
+          params = params)
     ).throttle(
       throttleRate.elements,
       throttleRate.per,
@@ -29,12 +37,21 @@ object SierraSource {
     ).mapConcat(identity)
   }
 
-  def apply(apiUrl: String, oauthKey: String, oauthSecret: String)(
+  def apply(
+    apiUrl: String,
+    oauthKey: String,
+    oauthSecret: String
+  )(
     resourceType: String,
     params: Map[String, String]): Source[Json, NotUsed] = {
 
     Source.fromGraph(
-      new SierraPageSource(apiUrl, oauthKey, oauthSecret)(resourceType, params)
+      new SierraPageSource(
+        apiUrl = apiUrl,
+        oauthKey = oauthKey,
+        oauthSecret = oauthSecret)(
+          resourceType = resourceType,
+          params = params)
     ).mapConcat(identity)
   }
 

--- a/src/main/scala/uk/ac/wellcome/sierra/SierraSource.scala
+++ b/src/main/scala/uk/ac/wellcome/sierra/SierraSource.scala
@@ -17,7 +17,8 @@ object SierraSource {
     apiUrl: String,
     oauthKey: String,
     oauthSecret: String,
-    throttleRate: ThrottleRate = ThrottleRate(elements = 0, per = 0 seconds)
+    throttleRate: ThrottleRate = ThrottleRate(elements = 0, per = 0 seconds),
+    timeoutMs: Int = 10000
   )(
     resourceType: String,
     params: Map[String, String]): Source[Json, NotUsed] = {

--- a/src/main/scala/uk/ac/wellcome/sierra/SierraSource.scala
+++ b/src/main/scala/uk/ac/wellcome/sierra/SierraSource.scala
@@ -27,7 +27,8 @@ object SierraSource {
       new SierraPageSource(
         apiUrl = apiUrl,
         oauthKey = oauthKey,
-        oauthSecret = oauthSecret)(
+        oauthSecret = oauthSecret,
+        timeoutMs = timeoutMs)(
           resourceType = resourceType,
           params = params)
     )

--- a/src/test/scala/uk/ac/wellcome/sierra/SierraStreamSourceTest.scala
+++ b/src/test/scala/uk/ac/wellcome/sierra/SierraStreamSourceTest.scala
@@ -1,5 +1,6 @@
 package uk.ac.wellcome.sierra
 
+import java.net.SocketTimeoutException
 import java.time.temporal.ChronoUnit
 import java.time.Instant
 
@@ -91,6 +92,8 @@ class SierraStreamSourceTest
   }
 
   it("respects the specified timeout parameter") {
+    // The default timeout is 10000 ms, so with default settings we'd
+    // expect to get a 200 OK for this response.
     stubFor(
       get(urlMatching("/bibs")).willReturn(
         aResponse()
@@ -103,14 +106,13 @@ class SierraStreamSourceTest
       apiUrl = sierraWireMockUrl,
       oauthKey = oauthKey,
       oauthSecret = oauthSecret,
-      timeoutMs = 2000
+      timeoutMs = 200
     )("bibs", Map.empty)
 
     val future = source.take(1).runWith(Sink.head[Json])
 
     whenReady(future.failed) { ex =>
-      ex shouldBe a [RuntimeException]
-      ex.getMessage should include ("Timeout")
+      ex shouldBe a [SocketTimeoutException]
     }
   }
 }


### PR DESCRIPTION
This brings across the patch we've been using in the Sierra reader for a while, letting us configure a longer HTTP timeout.